### PR TITLE
Added adadomain integration

### DIFF
--- a/src/api/extension/index.js
+++ b/src/api/extension/index.js
@@ -1,5 +1,6 @@
 import {
   ADA_HANDLE,
+  ADA_DOMAIN,
   APIError,
   DataSignError,
   ERROR,
@@ -1451,6 +1452,21 @@ export const getAdaHandle = async (assetName) => {
   const assetNameHex = Buffer.from(assetName).toString('hex');
   if (!assetNameHex || assetNameHex.length == 0) return null;
   const policy = ADA_HANDLE[network.id];
+  const asset = policy + assetNameHex;
+  const resolvedAddress = await blockfrostRequest(`/assets/${asset}/addresses`);
+  if (!resolvedAddress || resolvedAddress.error) return null;
+  return resolvedAddress[0].address;
+};
+
+/**
+ *
+ * @param {string} assetName utf8 encoded
+ */
+export const getAdaDomain = async (assetName) => {
+  const network = await getNetwork();
+  const assetNameHex = Buffer.from(assetName).toString('hex');
+  if (!assetNameHex || assetNameHex.length == 0) return null;
+  const policy = ADA_DOMAIN[network.id];
   const asset = policy + assetNameHex;
   const resolvedAddress = await blockfrostRequest(`/assets/${asset}/addresses`);
   if (!resolvedAddress || resolvedAddress.error) return null;

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -124,6 +124,11 @@ export const ADA_HANDLE = {
   testnet: '8d18d786e92776c824607fd8e193ec535c79dc61ea2405ddf3b09fe3',
 };
 
+export const ADA_DOMAIN = {
+  mainnet: 'e2bdb31c13a57d94934d01a4ca17cf3b2cac61d055637261b089c8f6',
+  testnet: 'e2bdb31c13a57d94934d01a4ca17cf3b2cac61d055637261b089c8f6', // No testnet domains, using the mainnet policy for compatibility
+};
+
 // Errors dApp Connector
 export const APIError = {
   InvalidRequest: {

--- a/src/ui/app/pages/send.jsx
+++ b/src/ui/app/pages/send.jsx
@@ -4,6 +4,7 @@ import {
   displayUnit,
   getAccounts,
   getAdaHandle,
+  getAdaDomain,
   getAsset,
   getCurrentAccount,
   getMilkomedaData,
@@ -859,19 +860,23 @@ const AddressPopup = ({
               setTimeout(() => e.target.blur());
             }}
             fontSize="xs"
-            placeholder="Address, $handle or Milkomeda"
+            placeholder="Address, $handle, adadomain or Milkomeda"
             // placeholder="Address or $handle"
             onInput={async (e) => {
               clearTimeout(addressTimer);
               const val = e.target.value;
               let addr;
               let isHandle = false;
+              let isDomain = false;
               let isM1 = false;
               addr = { result: val };
               if (!e.target.value) {
                 addr = { result: '', display: '' };
               } else if (val.startsWith('$')) {
                 isHandle = true;
+                addr = { display: val };
+              } else if (val.endsWith('.ada')) {
+                isDomain = true;
                 addr = { display: val };
               } else if (val.startsWith('0x')) {
                 if (isValidEthAddress(val)) {
@@ -922,6 +927,30 @@ const AddressPopup = ({
                     };
                   }
                   triggerTxUpdate(() => setAddress(handleAddr));
+                  onClose();
+                }, 300);
+              } else if (isDomain) {
+                addressTimer = setTimeout(async () => {
+                  // checking for Adadomain after 300ms
+                  let domainAddr = { error: 'adadomain not found' };
+                  const adadomain = e.target.value.substr(0, e.target.value.lastIndexOf('.'));
+                  const resolvedAddress = await getAdaDomain(adadomain);
+                  if (
+                    adadomain.length > 1 &&
+                    (await isValidAddress(resolvedAddress))
+                  ) {
+                    domainAddr = {
+                      result: resolvedAddress,
+                      display: e.target.value,
+                    };
+                  } else {
+                    domainAddr = {
+                      result: '',
+                      display: e.target.value,
+                      error: 'adadomain not found',
+                    };
+                  }
+                  triggerTxUpdate(() => setAddress(domainAddr));
                   onClose();
                 }, 300);
               } else if (isM1) {


### PR DESCRIPTION
Added support for adadomains to work in the same way $handles are
dealt with.

The UI has been modified to state that addrresses, $handles,
adadomains or Milkomedia can be used.

Summary of changes:
    src/config/config.js
        exporting ADA_DOMAIN with the policy ID from adadomain
            proof of policy ID: https://presale.adadomains.io/

    src/api/extension/index.js
        imported ADA_DOMAIN from config.js
        added "getAdaDomain" function using the $handle code but referencing ADA_DOMAIN and different variable names to distinguish it from the $handle code

    src/ui/app/pages/send.jsx
        Adjusted the placeholder to include adadomains
        Added variable "isDomain" to store if the entered text is an adadomain
        Checks if the text ends with ".ada" and assumes that the entered text is an adadomain
        If it is an adadomain it uses the same code as it uses for $handle except for:
            variable names reflecting the fact that this code is about adadomains
            using getAdaDomain instead of getAdaHandle to find the address
            using the text up to the last occurence of a dot instead of everything except for the "$"