### PR TITLE
Readme Fix for "getRewardAddress is not a function" error

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Will return the same address as the one in `cardano.getUsedAddresses()`.
 cardano.getRewardAddresses() : [RewardAddress]
 ```
 
-`RewardAddresses` is a hex encoded bytes string.
+`RewardAddress` is a hex encoded bytes string.
 
 **Note** This function will return an array of length `1` and will always return the same single address.
 


### PR DESCRIPTION
While trying to get user's stake address, the error "getRewardAddress is not a function" was returned.
And according to CIP-0030, the correct method name is "getRewardAddresses", which returns an array.