### PR TITLE
Fix `AssetFingerprint` inputs

### DIFF
--- a/src/api/extension/index.js
+++ b/src/api/extension/index.js
@@ -1717,11 +1717,12 @@ export const getAsset = async (unit) => {
   } else {
     asset.unit = unit;
     asset.policy = unit.slice(0, 56);
-    asset.name = Buffer.from(unit.slice(56), 'hex').toString();
+    asset.name = Buffer.from(unit.slice(56), 'hex');
     asset.fingerprint = new AssetFingerprint(
       Buffer.from(asset.policy, 'hex'),
-      Buffer.from(asset.name)
+      asset.name
     ).fingerprint();
+    asset.name = asset.name.toString();
     let result = await blockfrostRequest(`/assets/${unit}`);
     if (!result || result.error) {
       result = {};

--- a/src/ui/app/pages/wallet.jsx
+++ b/src/ui/app/pages/wallet.jsx
@@ -178,11 +178,12 @@ const Wallet = () => {
     currentAccount.nft = [];
     currentAccount.assets.forEach((asset) => {
       asset.policy = asset.unit.slice(0, 56);
-      asset.name = Buffer.from(asset.unit.slice(56), 'hex').toString();
+      asset.name = Buffer.from(asset.unit.slice(56), 'hex');
       asset.fingerprint = new AssetFingerprint(
         Buffer.from(asset.policy, 'hex'),
-        Buffer.from(asset.name)
+        asset.name
       ).fingerprint();
+      asset.name = asset.name.toString();
       if (asset.has_nft_onchain_metadata === true)
         currentAccount.nft.push(asset);
       else currentAccount.ft.push(asset);


### PR DESCRIPTION
Encoding the token name as a string can mangle bytes that are outside of the ASCII range, resulting in an incorrect asset fingerprint. This change passes the `Buffer` value directly to produce fingerprints consistent with CIP14.