### PR TITLE
Solves Issue #564: Line Breaks ("\n") isn't supported in Message shown when prompt to sign (signData method) (CIP30).

### DIFF
--- a/src/ui/app/pages/signData.jsx
+++ b/src/ui/app/pages/signData.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useMemo} from 'react';
 import { getCurrentAccount, isHW, signData, signDataCIP30 } from '../../../api/extension';
 import { Box, Text } from '@chakra-ui/layout';
 import Account from '../components/account';
@@ -27,6 +27,18 @@ const SignData = ({ request, controller }) => {
     const payload = Buffer.from(request.data.payload, 'hex').toString('utf8');
     setPayload(payload);
   };
+
+  const signDataMsg = useMemo(() => {
+    const result = [];
+    payload.split(/\r?\n/).forEach(line => {
+      result.push(
+          <p style={{wordBreak: 'break-word', paddingBlockEnd: '8px'}}>
+            {line}
+          </p>
+      );
+    })
+    return result;
+  }, [payload]);
 
   const getAddress = async () => {
     await Loader.load();
@@ -118,13 +130,15 @@ const SignData = ({ request, controller }) => {
           <Box h="4" />
           <Box
             width="76%"
-            height="200px"
+            height="278px"
             rounded="xl"
             background={background}
             padding="2.5"
             wordBreak="break-all"
           >
-            <Scrollbars autoHide>{payload}</Scrollbars>
+            <Scrollbars autoHide>
+              {signDataMsg}
+            </Scrollbars>
           </Box>
 
           <Box


### PR DESCRIPTION
- Payload is now splitted into separated lines by line breaks received in the msg data payload. (/r, /r/n, /n)
- increased text area height to fill the blank gap (more room for message data content).

**Example for the change:**
Before:
![Nami Before](https://user-images.githubusercontent.com/3818746/194759578-eddef7b1-45a2-42e0-b7da-85827a517134.PNG)

After:
![Nami After](https://user-images.githubusercontent.com/3818746/194759591-183d1a6b-7781-4d35-a77e-61308cd149b6.PNG)

Raw msg sign data payload used:
```java
String message = "Welcome to adabox.io!\n\n" +
                    "Click to sign in and accept the Adabox Terms of Service: https://adabox.io/tos\n\n" +
                    "This request will not trigger a blockchain transaction or cost any fees.\n\n" +
                    "Your authentication status will reset after 24 hours.\n\n" +
                    nonceTitle + nonce;
```