### PR TITLE
Test for CIP-25 version 2 in Blockfrost metadata

### DIFF
--- a/src/api/extension/index.js
+++ b/src/api/extension/index.js
@@ -1728,15 +1728,20 @@ export const getAsset = async (unit) => {
       result = {};
       asset.mint = true;
     }
+    const onchainMetadata = 
+      result.onchain_metadata &&
+        ((result.onchain_metadata.version === 2 && 
+           result.onchain_metadata?.[`0x${asset.policy}`]?.[`0x${unit.slice(56)}`]) ||
+        result.onchain_metadata);
     asset.displayName =
-      (result.onchain_metadata && result.onchain_metadata.name) ||
+      (onchainMetadata && onchainMetadata.name) ||
       (result.metadata && result.metadata.name) ||
       asset.name;
     asset.image =
-      (result.onchain_metadata &&
-        result.onchain_metadata.image &&
+      (onchainMetadata &&
+        onchainMetadata.image &&
         linkToSrc(
-          convertMetadataPropToString(result.onchain_metadata.image)
+          convertMetadataPropToString(onchainMetadata.image)
         )) ||
       (result.metadata &&
         result.metadata.logo &&


### PR DESCRIPTION
Given that Blockfrost doesn't currently support version 2 of CIP-25 and instead returns the entire 721 metadata entry, I think a temporary check for this within Nami may be appropriate.