### PR TITLE
Use metadata in send/transaction popovers and avatar fallbacks

### DIFF
--- a/src/ui/app/components/asset.jsx
+++ b/src/ui/app/components/asset.jsx
@@ -99,10 +99,10 @@ const Asset = ({ asset, enableSend, ...props }) => {
                       {settings.adaSymbol}
                     </Box>
                   ) : (
-                    <Avatar width="full" height="full" name={token.name} />
+                    <Avatar width="full" height="full" name={token.displayName} />
                   )
                 ) : (
-                  <Fallback name={token.name} />
+                  <Fallback name={token.displayName} />
                 )
               }
             />

--- a/src/ui/app/components/assetBadge.jsx
+++ b/src/ui/app/components/assetBadge.jsx
@@ -99,9 +99,9 @@ const AssetBadge = ({ asset, onRemove, onInput, onLoad }) => {
                       src={token.image}
                       fallback={
                         !token.image ? (
-                          <Avatar size="xs" name={token.name} />
+                          <Avatar size="xs" name={token.displayName} />
                         ) : (
-                          <Fallback name={token.name} />
+                          <Fallback name={token.displayName} />
                         )
                       }
                     />

--- a/src/ui/app/components/assetPopoverDiff.jsx
+++ b/src/ui/app/components/assetPopoverDiff.jsx
@@ -10,7 +10,7 @@ import {
   PopoverTrigger,
 } from '@chakra-ui/popover';
 import { Box, Stack, Text } from '@chakra-ui/layout';
-import { Button, Skeleton } from '@chakra-ui/react';
+import { Button, Image, Skeleton } from '@chakra-ui/react';
 import { ChevronDownIcon } from '@chakra-ui/icons';
 import { Portal } from '@chakra-ui/portal';
 import { FixedSizeList as List } from 'react-window';
@@ -150,7 +150,16 @@ const Asset = ({ asset, isDifference }) => {
           alignItems="center"
           justifyContent="start"
         >
-          <Avatar userSelect="none" size="xs" name={token.name} />
+          <Image
+            src={token.image}
+            width="24px"
+            rounded="sm"
+            draggable={false}
+            userSelect="none"
+            fallback={
+              <Avatar userSelect="none" size="xs" name={token.displayName} />
+            }
+          />
 
           <Box
             textAlign="left"
@@ -161,7 +170,7 @@ const Asset = ({ asset, isDifference }) => {
             <Copy label="Copied asset" copy={token.fingerprint}>
               <Box mb="-0.5">
                 <MiddleEllipsis>
-                  <span>{token.name}</span>
+                  <span>{token.displayName}</span>
                 </MiddleEllipsis>
               </Box>
               <Box whiteSpace="nowrap" fontSize="xx-small" fontWeight="light">

--- a/src/ui/app/components/collectible.jsx
+++ b/src/ui/app/components/collectible.jsx
@@ -71,9 +71,9 @@ const Collectible = React.forwardRef(({ asset }, ref) => {
               src={token.image}
               fallback={
                 !token.image ? (
-                  <Avatar width="210px" height="210px" name={token.name} />
+                  <Avatar width="210px" height="210px" name={token.displayName} />
                 ) : (
-                  <Fallback name={token.name} />
+                  <Fallback name={token.displayName} />
                 )
               }
             />

--- a/src/ui/app/pages/send.jsx
+++ b/src/ui/app/pages/send.jsx
@@ -57,6 +57,7 @@ import { useDisclosure } from '@chakra-ui/hooks';
 import AssetBadge from '../components/assetBadge';
 import { ERROR } from '../../../config/config';
 import {
+  Image,
   InputRightElement,
   InputLeftElement,
   Spinner,
@@ -1429,6 +1430,7 @@ const Asset = ({ asset, choice, select, setChoice, onClose, addAssets }) => {
         >
           <Selection
             asset={asset}
+            token={token}
             select={select}
             choice={choice}
             setChoice={setChoice}
@@ -1442,7 +1444,7 @@ const Asset = ({ asset, choice, select, setChoice, onClose, addAssets }) => {
           >
             <Box mb="-1px">
               <MiddleEllipsis>
-                <span>{token.name}</span>
+                <span>{token.displayName}</span>
               </MiddleEllipsis>
             </Box>
             <Box whiteSpace="nowrap" fontSize="xx-small" fontWeight="light">
@@ -1460,8 +1462,14 @@ const Asset = ({ asset, choice, select, setChoice, onClose, addAssets }) => {
   );
 };
 
-const Selection = ({ select, asset, choice, setChoice }) => {
+const Selection = ({ select, asset, token, choice, setChoice }) => {
   const selectColor = useColorModeValue('orange.500', 'orange.200');
+
+  const selectAsset = (e) => {
+    choice[asset.unit] = true;
+    setChoice({ ...choice });
+  }
+
   return (
     <Box
       rounded="full"
@@ -1487,14 +1495,21 @@ const Selection = ({ select, asset, choice, setChoice }) => {
           <CheckIcon />
         </Box>
       ) : (
-        <Avatar
-          onClick={(e) => {
-            choice[asset.unit] = true;
-            setChoice({ ...choice });
-          }}
+        <Image
+          src={token.image}
+          width="24px"
+          rounded="sm"
+          draggable={false}
+          onClick={selectAsset}
           userSelect="none"
-          size="xs"
-          name={asset.name}
+          fallback={
+            <Avatar
+              onClick={selectAsset}
+              userSelect="none"
+              size="xs"
+              name={token.displayName}
+            />
+          }
         />
       )}
     </Box>


### PR DESCRIPTION
These changes reuse token metadata in Nami's submenus and prefer the display name over the asset name where relevant.