### PR TITLE
Allow users to change password without having to reset

### DIFF
--- a/src/ui/app/components/changePasswordModal.jsx
+++ b/src/ui/app/components/changePasswordModal.jsx
@@ -1,0 +1,216 @@
+import {Button} from '@chakra-ui/button';
+import {Input, InputGroup, InputRightElement} from '@chakra-ui/input';
+import {Box, Text} from '@chakra-ui/layout';
+import {Modal, ModalBody, ModalContent, ModalFooter, ModalHeader, ModalOverlay,} from '@chakra-ui/modal';
+import React from 'react';
+import {useToast} from "@chakra-ui/react";
+import {STORAGE} from "../../../config/config";
+import {decryptWithPassword, encryptWithPassword, getStorage, setStorage} from "../../../api/extension";
+import Loader from "../../../api/loader";
+import {useDisclosure} from "@chakra-ui/hooks";
+
+export const ChangePasswordModal = React.forwardRef((props, ref) => {
+
+	const cancelRef = React.useRef();
+	const inputRef = React.useRef();
+	const toast = useToast();
+
+	const { isOpen, onOpen, onClose } = useDisclosure();
+	const [isLoading, setIsLoading] = React.useState(false);
+	const [state, setState] = React.useState({
+		currentPassword: '',
+		newPassword: '',
+		repeatPassword: '',
+		matchingPassword: false,
+		passwordLen: null,
+		show: false,
+	});
+
+  React.useEffect(() => {
+    setState({
+			currentPassword: '',
+			newPassword: '',
+			repeatPassword: '',
+			passwordLen: null,
+			show: false,
+    });
+  }, [isOpen]);
+
+
+	React.useImperativeHandle(ref, () => ({
+		openModal() {
+			onOpen();
+		},
+	}));
+
+
+  const confirmHandler = async () => {
+
+    if (!state.currentPassword || !state.newPassword || !state.repeatPassword || state.newPassword !== state.repeatPassword )
+			return;
+
+		setIsLoading(true)
+
+		try {
+
+			await Loader.load();
+
+			const encryptedRootKey = await getStorage(STORAGE.encryptedKey);
+			const decryptedRootKey = await decryptWithPassword(state.currentPassword, encryptedRootKey)
+
+			const rootKey = Loader.Cardano.Bip32PrivateKey.from_bytes(Buffer.from(decryptedRootKey, 'hex'));
+			const newlyEncryptedRootKey = await encryptWithPassword(state.newPassword, rootKey.as_bytes());
+
+			rootKey.free();
+
+			await setStorage({ [STORAGE.encryptedKey]: newlyEncryptedRootKey });
+
+			toast({
+				title: 'Password updated',
+				status: 'success',
+				duration: 5000,
+			});
+
+			onClose()
+
+		} catch (e) {
+
+			toast({
+				title: e && e.message ? e.message : 'Password update failed!',
+				status: 'error',
+				duration: 5000,
+			});
+
+		}
+
+		setIsLoading(false)
+
+  };
+
+  return (
+    <Modal
+      size="xs"
+      isOpen={isOpen}
+      onClose={onClose}
+      isCentered
+      initialFocusRef={inputRef}
+    >
+      <ModalOverlay />
+      <ModalContent m={0}>
+        <ModalHeader fontSize="md">Change Password</ModalHeader>
+        <ModalBody>
+
+					<Box mb="6" fontSize="sm" width="full">
+						Type your current password and new password below, if you want to continue.
+					</Box>
+
+					<Box>
+						<InputGroup size="md">
+							<Input
+								ref={inputRef}
+								focusBorderColor="teal.400"
+								variant="filled"
+								pr="4.5rem"
+								type={state.show ? 'text' : 'password'}
+								onChange={(e) =>
+									setState((s) => ({ ...s, currentPassword: e.target.value }))
+								}
+								placeholder="Enter current password"
+							/>
+							<InputRightElement width="4.5rem">
+								<Button
+									h="1.75rem"
+									size="sm"
+									onClick={() => setState((s) => ({ ...s, show: !s.show }))}
+								>
+									{state.show ? 'Hide' : 'Show'}
+								</Button>
+							</InputRightElement>
+						</InputGroup>
+					</Box>
+
+					<Box height="4" />
+
+					<Box>
+						<InputGroup size="md">
+							<Input
+								focusBorderColor="teal.400"
+								variant="filled"
+								pr="4.5rem"
+								isInvalid={state.passwordLen === false}
+								type={state.show ? 'text' : 'password'}
+								onChange={(e) =>
+									setState((s) => ({ ...s, newPassword: e.target.value }))
+								}
+								onBlur={(e) =>
+									setState((s) => ({ ...s, passwordLen: e.target.value ? e.target.value.length >= 8 : null }))
+								}
+								placeholder="Enter new password"
+							/>
+							<InputRightElement width="4.5rem">
+								<Button
+									h="1.75rem"
+									size="sm"
+									onClick={() => setState((s) => ({ ...s, show: !s.show }))}
+								>
+									{state.show ? 'Hide' : 'Show'}
+								</Button>
+							</InputRightElement>
+						</InputGroup>
+					</Box>
+
+					{(state.passwordLen === false ) && (
+						<Text color="red.300">Password must be at least 8 characters long</Text>
+					)}
+
+					<Box height="4" />
+
+					<Box>
+						<InputGroup size="md">
+							<Input
+								focusBorderColor="teal.400"
+								variant="filled"
+								isInvalid={state.repeatPassword && state.newPassword !== state.repeatPassword}
+								pr="4.5rem"
+								type={state.show ? 'text' : 'password'}
+								onChange={(e) =>
+									setState((s) => ({ ...s, repeatPassword: e.target.value }))
+								}
+								placeholder="Repeat new password"
+							/>
+							<InputRightElement width="4.5rem">
+								<Button
+									h="1.75rem"
+									size="sm"
+									onClick={() => setState((s) => ({ ...s, show: !s.show }))}
+								>
+									{state.show ? 'Hide' : 'Show'}
+								</Button>
+							</InputRightElement>
+						</InputGroup>
+
+						{(state.repeatPassword && state.repeatPassword !== state.newPassword) && (
+							<Text color="red.300">Password doesn't match</Text>
+						)}
+					</Box>
+
+        </ModalBody>
+
+        <ModalFooter>
+          <Button mr={3} variant="ghost" onClick={onClose} ref={cancelRef}>
+            Cancel
+          </Button>
+
+          <Button
+            isDisabled={!state.currentPassword || !state.newPassword || !state.repeatPassword || state.newPassword !== state.repeatPassword || state.passwordLen === false}
+            isLoading={isLoading}
+            colorScheme="teal"
+            onClick={confirmHandler}
+          >
+            Confirm
+          </Button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+});

--- a/src/ui/app/pages/settings.jsx
+++ b/src/ui/app/pages/settings.jsx
@@ -43,6 +43,7 @@ import ConfirmModal from '../components/confirmModal';
 import { useStoreState, useStoreActions } from 'easy-peasy';
 import { MdModeEdit } from 'react-icons/md';
 import AvatarLoader from '../components/avatarLoader';
+import {ChangePasswordModal} from "../components/changePasswordModal";
 
 const Settings = () => {
   const history = useHistory();
@@ -141,6 +142,7 @@ const GeneralSettings = ({ accountRef }) => {
   const [originalName, setOriginalName] = React.useState('');
   const { colorMode, toggleColorMode } = useColorMode();
   const ref = React.useRef();
+	const changePasswordRef = React.useRef();
 
   const nameHandler = async () => {
     await setAccountName(account.name);
@@ -269,6 +271,10 @@ const GeneralSettings = ({ accountRef }) => {
       <Button disabled={refreshed} size="sm" onClick={refreshHandler}>
         Refresh Balance
       </Button>
+			<Box height="5" />
+      <Button colorScheme="orange" size="sm" onClick={() => changePasswordRef.current.openModal()}>
+          Change Password
+      </Button>
       <Box height="10" />
       <Button
         size="xs"
@@ -293,6 +299,7 @@ const GeneralSettings = ({ accountRef }) => {
           if (status === true) window.close();
         }}
       />
+			<ChangePasswordModal ref={changePasswordRef}/>
     </>
   );
 };


### PR DESCRIPTION
The purpose of this PR is to allow users to change their wallet password without having to reset and import again.

The methodology is quite simple. By default, Nami encrypts the rootKey and saves it in the storage. When a user prompts to change their password, Nami will ask for their old and new passwords.

The old password will be used to decrypt the previously encrypted root key ( and throw an error if it fails ) and then encrypt the root key again with the new password and saves it into the storage.

This PR was motivated by the Issue [#38](https://github.com/berry-pool/nami/issues/38)