### PR TITLE
Feat/update manifest v3

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,10 +1,10 @@
 {
-  "manifest_version": 2,
+  "manifest_version": 3,
+  "name": "Nami",
   "version": "3.4.4",
   "description": "A wallet to experience Cardano to the fullest",
-  "name": "Nami",
-  "background": { "scripts": ["background.bundle.js"], "persistent": false },
-  "browser_action": {
+  "background": { "service_worker": "background.bundle.js" },
+  "action": {
     "default_popup": "mainPopup.html",
     "default_icon": "icon-34.png"
   },
@@ -13,18 +13,25 @@
   },
   "content_scripts": [
     {
-      "matches": ["http://*/*", "https://*/*", "file://*/*"],
+      "matches": ["http://*/*", "https://*/*", "<all_urls>"],
       "js": ["contentScript.bundle.js"],
       "run_at": "document_start"
     }
   ],
   "web_accessible_resources": [
-    "icon-128.png",
-    "icon-34.png",
-    "injected.bundle.js",
-    "internalPopup.html",
-    "Trezor/*"
+    {
+      "resources": [
+        "icon-128.png",
+        "icon-34.png",
+        "injected.bundle.js",
+        "internalPopup.html",
+        "Trezor/*"
+      ],
+      "matches": ["http://*/*", "https://*/*", "<all_urls>"]
+    }
   ],
-  "permissions": ["storage", "chrome://favicon/", "unlimitedStorage"],
-  "content_security_policy": "script-src 'self' 'unsafe-eval'; object-src 'self';"
+  "content_security_policy": {
+    "extension_pages": "script-src 'self' 'wasm-unsafe-eval'; object-src 'self';"
+  },
+  "permissions": [ "storage", "unlimitedStorage"]
 }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -27,7 +27,7 @@
         "internalPopup.html",
         "Trezor/*"
       ],
-      "matches": ["http://*/*", "https://*/*", "<all_urls>"]
+      "matches": ["http://*/*", "https://*/*", "file://*/*"]
     }
   ],
   "content_security_policy": {


### PR DESCRIPTION
Nami is still using Manifest V2. Currently its not possible to upload new applications to the Chrome store with this version. Existing applications, such as Nami Wallet, can continue to be updated **until June 2023**. However, the definitive timeline for when these restrictions will apply is unclear. More information can be found on the following sources:

1. Blog: https://developer.chrome.com/blog/more-mv2-transition/
2. Manifest V2 support timeline: https://developer.chrome.com/docs/extensions/migrating/mv2-sunset/

Currently, the following error is displayed: "`Manifest version 2 is deprecated, and support will be removed in 2023.`" This means that Manifest V2 support will be removed in 2023.

One of the main reasons for not upgrading to V3 is because it was not compatible with WASM, which resulted in the following error: "`Uncaught (in promise) CompileError: WebAssembly.instantiateStreaming(): Refused to compile or instantiate WebAssembly module because neither 'wasm-eval' nor 'unsafe-eval' is an allowed source of script in the following Content Security Policy directive: 'script-src 'self''`".

Now that V3 supports a new policy, `wasm-unsafe-eval`, it allows the running of WASM code like the CSL. However, upgrading to version 3 presents another problem, as the localStorage API will no longer be supported in Chrome extensions. Updating the manifest will result in the following error: "`Uncaught ReferenceError: localStorage is not defined`".

As updating the manifest **will be mandatory** sooner or later, it is advisable to start migrating to another data persistence solution that is supported. There are two alternatives to consider:

1. Google storage: https://developer.chrome.com/docs/extensions/reference/storage/
2. IndexedDB from Firefox: https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API/Using_IndexedDB

I recommend exploring both alternatives to determine which one best suits the needs of Nami.



