### PR TITLE
Update index.js

### DIFF
--- a/src/api/extension/index.js
+++ b/src/api/extension/index.js
@@ -288,7 +288,8 @@ export const getUtxos = async (amount = undefined, paginate = undefined) => {
   const currentAccount = await getCurrentAccount();
   let result = [];
   let page = paginate && paginate.page ? paginate.page + 1 : 1;
-  const limit = paginate && paginate.limit ? `&count=${paginate.limit}` : '';
+  let page_limit = paginate && paginate.limit ? Math.min(paginate.limit, 100) : false;
+  const limit = page_limit ? `&count=${page_limit}` : '';
   while (true) {
     let pageResult = await blockfrostRequest(
       `/addresses/${currentAccount.paymentKeyHashBech32}/utxos?page=${page}${limit}`


### PR DESCRIPTION
Update extension/index.js to account for the fact that Blockfrost page limit is set to a maximum of 100. Providing a larger integer value to paginate.limit results in an error to the user.