### PR TITLE
Added support for CIP68 handle

### DIFF
--- a/src/api/extension/index.js
+++ b/src/api/extension/index.js
@@ -1547,14 +1547,15 @@ export const initHW = async ({ device, id }) => {
  * @param {string} assetName utf8 encoded
  */
 export const getAdaHandle = async (assetName) => {
-  const network = await getNetwork();
-  const assetNameHex = Buffer.from(assetName).toString('hex');
-  if (!assetNameHex || assetNameHex.length == 0) return null;
-  const policy = ADA_HANDLE[network.id];
-  const asset = policy + assetNameHex;
-  const resolvedAddress = await blockfrostRequest(`/assets/${asset}/addresses`);
-  if (!resolvedAddress || resolvedAddress.error) return null;
-  return resolvedAddress[0].address;
+  try {
+    const network = await getNetwork();
+    if( !network || network.id != 'mainnet' ) return null;
+    const response = await fetch(`https://api.handle.me/handles/${assetName}`)
+    const data = response && response.ok ? await response.json() : null
+    return data && data.resolved_addresses && data.resolved_addresses.ada ? data.resolved_addresses.ada : null
+  } catch (e) {
+    return null
+  }
 };
 
 /**


### PR DESCRIPTION
### Added support for recently introduced CIP-68 Ada Handles.

Previously ada handles were following CIP-25 standards where we can retrieve the owner address by encoding the handle to hex, adding a policy prefix to get the asset ID, and sending a request to Blockfrost.

Now that they have introduced personalization by upgrading your CIP-25 handle to CIP-68, we have handles with both token standards exist. Unfortunately, the old method doesn't work for CIP-68 handles as they have an additional prefix (000de140) before the hex-encoded asset name.

I have replaced the old ```getAdaHandle``` method with the new official API which is more fast and reliable - https://api.handle.me/swagger

You can test the changes by resolving the following handle.

- $neo.ada (CIP-68 Standard)
- $neo.brave (CIP-25 Standard)

Both handles will be resolved by the new official API. However, the old implementation won't be able to resolve the CIP-68 handle.

The official API has a rate limit of 5 requests per second, per IP which should be fine as the requests are being sent from the user's machine, not via any gateway. Hence the chance of hitting 5 requests per second it quite low.


